### PR TITLE
Remove `-f` flag when `readlink` and use `od` for more accurate result

### DIFF
--- a/vdesktop
+++ b/vdesktop
@@ -392,7 +392,7 @@ if [ "$VDESKTOP_LOCAL_BINARIES" == 'no' ];then
 fi
 
 #exit if guest is 64 bit and host is 32 bit
-if [ ! -z "$(file "${MOUNTPOINT}$(readlink -f "${MOUNTPOINT}/sbin/init")" | grep 64)" ] && [ "$(uname -m)" == 'armv7l' ];then
+if [ "$(od -An -t x1 -j 4 -N 1 "${MOUNTPOINT}$(readlink ${MOUNTPOINT}/sbin/init)")" = ' 02' ] && [ "$(uname -m)" == 'armv7l' ];then
   error "You cannot boot a 64 bit OS without enabling the 64 bit kernel.
 To enable the 64 bit kernel, add 'arm_64bit=1' to /boot/config.txt and then reboot."
 fi


### PR DESCRIPTION
Fix vdesktop not detecting guest OS is in 64 bit.  

The final symlink of `${MOUNTPOINT}/sbin/init` is `${MOUNTPOINT}/usr/lib/systemd/systemd`, and I don't know why it returns this when I want to boot a 64-bit OS: 

```
/media/pi/vdesktop/usr/lib/systemd/systemd: ELF 32-bit LSB pie executable, ARM, EABI5 version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-armhf.so.3, BuildID[sha1]=ca3425718ce4bf3dabccc5b4c971a592309e2806, for GNU/Linux 3.2.0, stripped
```

Sometimes it even returns `/media/pi/vdesktop/usr/lib/systemd/systemd: cannot open '/media/pi/vdesktop/usr/lib/systemd/systemd' (No such file or directory)`.

But the first symlink, `${MOUNTPOINT}/lib/systemd/systemd` returns the right thing:
```
/media/pi/vdesktop/lib/systemd/systemd: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (SYSV), dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, for GNU/Linux 3.7.0, BuildID[sha1]=c3174499a703cbe3b83c28aef6ec1e9ae27196b9, stripped
```


Also, I am using `od` method as Botspot used in pi-apps because it is more accurate than grepping from the `file` output. 